### PR TITLE
Required promise ~2.2 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "react/dns": "0.4.*",
         "react/event-loop": "0.4.*",
         "react/stream": "0.4.*",
+        "react/promise": "~2.2",
         "evenement/evenement": "~2.0"
     },
     "autoload": {


### PR DESCRIPTION
to ensure ExtendedPromiseInterface::done() availability so https://github.com/reactphp/http-client/pull/31 can be merged
