### PR TITLE
Change `$this` parameter in closure to `$that` to prevent memory leak.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -98,12 +98,12 @@ class Request implements WritableStreamInterface
         }
 
         if (!count($this->pendingWrites)) {
-            $this->on('headers-written', function ($this) {
-                foreach ($this->pendingWrites as $pw) {
-                    $this->write($pw);
+            $this->on('headers-written', function ($that) {
+                foreach ($that->pendingWrites as $pw) {
+                    $that->write($pw);
                 }
-                $this->pendingWrites = array();
-                $this->emit('drain', array($this));
+                $that->pendingWrites = array();
+                $that->emit('drain', array($that));
             });
         }
 


### PR DESCRIPTION
Using `$this` as a parameter name in a closure under PHP 7 causes a memory leak
under some specific circumstances which are present in this component.

Relevant PHP issue: https://bugs.php.net/bug.php?id=71737
More information: https://gist.github.com/jmalloc/e3db5842c2c4ab2a1edf
